### PR TITLE
v0.2.2 - Pre-release bugfixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 2 space indentation
+[*.{js, ts, jsx, tsx, json}]
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabky-js",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A JS package for programatically manipulating your app's browser tab (favicon and title).",
   "source": "src/index.ts",
   "main": "./dist/tabky-js.js",

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,12 +1,17 @@
 ## 0.2.2
+
 - Store references to canvases for different sizes
 - Clear canvas before drawing in each function
 - Scale the font size depending on canvas size (normalized to 32px)
+- Added `.editorconfig`
+- Prettified all files
 
 ## 0.2.1
+
 - Fix wrong type on `font` property of `addBadge()`
 
 ## 0.2.0
+
 - Implemented `addBadge()` for adding badges / counters to the favicon
 - Added changelog
 - Changed case for all files to kebab-case
@@ -14,6 +19,7 @@
 - Add JSDocs for all functions
 
 ## 0.1.0
+
 - Initial release of the library with Typescript support + basic functions for changing favicons
 - Setting up the build using `microbundle`
 - Implemented `swapFavicon()`
@@ -21,3 +27,5 @@
 - Implemented `resetFavicon()`
 - Implemented `resetTitle()`
 - Implemented `marqueeTitle()`
+
+`<link rel="icon" style="16x16px ...` and `<link rel="icon" style="32x32px ...`

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+- Store references to canvases for different sizes
+- Clear canvas before drawing in each function
+- Scale the font size depending on canvas size (normalized to 32px)
+
 ## 0.2.1
 - Fix wrong type on `font` property of `addBadge()`
 

--- a/src/helpers/async-load-image.ts
+++ b/src/helpers/async-load-image.ts
@@ -5,11 +5,11 @@
  * @returns {Promise<HTMLImageElement>} The loaded image
  */
 export const asyncLoadImage = (url: string): Promise<HTMLImageElement> => {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const image = new Image();
-    image.addEventListener('load', () => {
+    image.addEventListener("load", () => {
       resolve(image);
     });
     image.src = url;
   });
-}
+};

--- a/src/helpers/convert-emoji-to-image.ts
+++ b/src/helpers/convert-emoji-to-image.ts
@@ -4,21 +4,21 @@ export const convertEmojiToImage = (emoji: string, size = 32) => {
   const canvas = getCanvas(size);
   const context = canvas.getContext("2d");
 
-	// Drawing the emoji this way makes it a bit bigger then drawing it as an SVG.
-	// By adding an offset, we can make it roughly same size as the SVG version.
-	const offset = 3;
+  // Drawing the emoji this way makes it a bit bigger then drawing it as an SVG.
+  // By adding an offset, we can make it roughly same size as the SVG version.
+  const offset = 3;
 
-	if (!context) {
-		return '';
-	}
+  if (!context) {
+    return "";
+  }
 
-	// clear canvas.
-	context?.clearRect(0, 0, canvas.width, canvas.height);
+  // clear canvas.
+  context?.clearRect(0, 0, canvas.width, canvas.height);
 
   context.font = `${size - offset}px serif`;
   context.textAlign = "right";
   context.textBaseline = "bottom";
   context.fillText(emoji, size - offset, size);
 
-	return canvas.toDataURL('image/png');
+  return canvas.toDataURL("image/png");
 };

--- a/src/helpers/convert-emoji-to-image.ts
+++ b/src/helpers/convert-emoji-to-image.ts
@@ -12,6 +12,9 @@ export const convertEmojiToImage = (emoji: string, size = 32) => {
 		return '';
 	}
 
+	// clear canvas.
+	context?.clearRect(0, 0, canvas.width, canvas.height);
+
   context.font = `${size - offset}px serif`;
   context.textAlign = "right";
   context.textBaseline = "bottom";

--- a/src/helpers/generate-favicon-with-badge.ts
+++ b/src/helpers/generate-favicon-with-badge.ts
@@ -15,7 +15,7 @@ export interface GenerateFaviconWithBadgeProps {
   font?: string;
   dotColor?: Color;
   innerDotColor?: Color;
-	countColor?: Color;
+  countColor?: Color;
   position?:
     | "top-left"
     | "top-right"
@@ -31,8 +31,11 @@ export interface GenerateFaviconWithBadgeProps {
  * @param faviconSize The size of the favicon. Used to calculate the font-size, normalized to 32px
  * @returns { dot: number, fontSize: number }
  */
-const convertSize = (size: GenerateFaviconWithBadgeProps["size"] = 'md', faviconSize: number) => {
-	const multiplierFromSize = faviconSize / 32;
+const convertSize = (
+  size: GenerateFaviconWithBadgeProps["size"] = "md",
+  faviconSize: number,
+) => {
+  const multiplierFromSize = faviconSize / 32;
   switch (size) {
     case "xs":
       return {
@@ -65,14 +68,14 @@ const convertSize = (size: GenerateFaviconWithBadgeProps["size"] = 'md', favicon
 export const generateFaviconWithBadge = async (
   link: HTMLLinkElement,
   {
-		type,
-		count = null,
-		size = 'md',
-		font = 'sans-serif',
-		dotColor = "#ff0000",
-		innerDotColor = "#ffffff",
-		countColor = "#ffffff",
-		position = "top-right",
+    type,
+    count = null,
+    size = "md",
+    font = "sans-serif",
+    dotColor = "#ff0000",
+    innerDotColor = "#ffffff",
+    countColor = "#ffffff",
+    position = "top-right",
   }: GenerateFaviconWithBadgeProps,
 ) => {
   // Try to read size from favicon link. Use last size. If doesn't exist or "any", assume 32x32px
@@ -99,8 +102,8 @@ export const generateFaviconWithBadge = async (
     return "";
   }
 
-	// Clear canvas
-	context?.clearRect(0, 0, canvas.width, canvas.height);
+  // Clear canvas
+  context?.clearRect(0, 0, canvas.width, canvas.height);
 
   const faviconImage = await asyncLoadImage(link.href);
 

--- a/src/helpers/generate-favicon-with-badge.ts
+++ b/src/helpers/generate-favicon-with-badge.ts
@@ -97,6 +97,9 @@ export const generateFaviconWithBadge = async (
     return "";
   }
 
+	// Clear canvas
+	context?.clearRect(0, 0, canvas.width, canvas.height);
+
   const faviconImage = await asyncLoadImage(link.href);
 
   // Draw image first

--- a/src/helpers/generate-favicon-with-badge.ts
+++ b/src/helpers/generate-favicon-with-badge.ts
@@ -28,34 +28,36 @@ export interface GenerateFaviconWithBadgeProps {
  * Converts the size prop to a percentage.
  *
  * @param size Size value to convert.
+ * @param faviconSize The size of the favicon. Used to calculate the font-size, normalized to 32px
  * @returns { dot: number, fontSize: number }
  */
-const convertSize = (size: GenerateFaviconWithBadgeProps["size"] = 'md') => {
+const convertSize = (size: GenerateFaviconWithBadgeProps["size"] = 'md', faviconSize: number) => {
+	const multiplierFromSize = faviconSize / 32;
   switch (size) {
     case "xs":
       return {
         dot: 0.2,
-        fontSize: 14,
+        fontSize: 14 * multiplierFromSize,
       };
     case "sm":
       return {
         dot: 0.25,
-        fontSize: 18,
+        fontSize: 18 * multiplierFromSize,
       };
     case "md":
       return {
         dot: 0.3,
-        fontSize: 20,
+        fontSize: 20 * multiplierFromSize,
       };
     case "lg":
       return {
         dot: 0.35,
-        fontSize: 24,
+        fontSize: 24 * multiplierFromSize,
       };
     case "full":
       return {
         dot: 0.5,
-        fontSize: 32,
+        fontSize: 32 * multiplierFromSize,
       };
   }
 };
@@ -116,7 +118,7 @@ export const generateFaviconWithBadge = async (
   );
 
   // Determine the circle position based on the position prop and the circle size.
-  const dotRadius = faviconSize * convertSize(size).dot;
+  const dotRadius = faviconSize * convertSize(size, faviconSize).dot;
   const innerDotRadius = dotRadius / 4;
   let x = 0;
   let y = 0;
@@ -171,7 +173,7 @@ export const generateFaviconWithBadge = async (
 
   // Draw the count text, inside the circle badge on innerX, innerY coordinate. Only for count.
   if (type === "count" && count !== null) {
-    context.font = `${convertSize(size).fontSize}px ${font}`;
+    context.font = `${convertSize(size, faviconSize).fontSize}px ${font}`;
     context.textAlign = "center";
     context.textBaseline = "middle";
     context.fillStyle = countColor;

--- a/src/helpers/get-canvas.ts
+++ b/src/helpers/get-canvas.ts
@@ -1,6 +1,10 @@
-export const getCanvas = (size = 32) => {
-  let canvas: HTMLCanvasElement|null = document.querySelector(`#canvas-${size}`);
-
+export const getCanvas = (size = 32): HTMLCanvasElement => {
+	const sizeString = size.toString();
+	if (window?.TabkyJs?.canvas[sizeString]) {
+		return window.TabkyJs.canvas[sizeString];
+	}
+	
+	let canvas: HTMLCanvasElement|null = document.querySelector(`#canvas-${size}`);
 	if (!canvas) {
 		canvas = document.createElement("canvas");
 		canvas.id = `canvas-${size}`;
@@ -8,11 +12,8 @@ export const getCanvas = (size = 32) => {
 		canvas.height = size;
 		canvas.style.display = "none";
 		document.body.appendChild(canvas);
-	} else {
-		// clear canvas
-		const context = canvas.getContext("2d");
-		context?.clearRect(0, 0, canvas.width, canvas.height);
 	}
 
+	window.TabkyJs.canvas[sizeString] = canvas;
 	return canvas;
 }

--- a/src/helpers/get-canvas.ts
+++ b/src/helpers/get-canvas.ts
@@ -1,19 +1,21 @@
 export const getCanvas = (size = 32): HTMLCanvasElement => {
-	const sizeString = size.toString();
-	if (window?.TabkyJs?.canvas[sizeString]) {
-		return window.TabkyJs.canvas[sizeString];
-	}
-	
-	let canvas: HTMLCanvasElement|null = document.querySelector(`#canvas-${size}`);
-	if (!canvas) {
-		canvas = document.createElement("canvas");
-		canvas.id = `canvas-${size}`;
-		canvas.width = size;
-		canvas.height = size;
-		canvas.style.display = "none";
-		document.body.appendChild(canvas);
-	}
+  const sizeString = size.toString();
+  if (window?.TabkyJs?.canvas[sizeString]) {
+    return window.TabkyJs.canvas[sizeString];
+  }
 
-	window.TabkyJs.canvas[sizeString] = canvas;
-	return canvas;
-}
+  let canvas: HTMLCanvasElement | null = document.querySelector(
+    `#canvas-${size}`,
+  );
+  if (!canvas) {
+    canvas = document.createElement("canvas");
+    canvas.id = `canvas-${size}`;
+    canvas.width = size;
+    canvas.height = size;
+    canvas.style.display = "none";
+    document.body.appendChild(canvas);
+  }
+
+  window.TabkyJs.canvas[sizeString] = canvas;
+  return canvas;
+};

--- a/src/helpers/get-favicon-href.ts
+++ b/src/helpers/get-favicon-href.ts
@@ -7,14 +7,17 @@ import { isEmoji } from "./is-emoji";
  * @param favicon The favicon URL or emoji.
  * @returns
  */
-export const getFaviconHref = (favicon: string, emojiCompatibilityMode: boolean) => {
+export const getFaviconHref = (
+  favicon: string,
+  emojiCompatibilityMode: boolean,
+) => {
   if (!isEmoji(favicon)) {
-		return favicon;
-	}
+    return favicon;
+  }
 
-	if (emojiCompatibilityMode) {
-		return convertEmojiToImage(favicon);
-	}
+  if (emojiCompatibilityMode) {
+    return convertEmojiToImage(favicon);
+  }
 
   return `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${favicon}</text></svg>`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ interface TabkyJs {
   focusCallbacks: CallableFunction[];
   blurCallbacks: CallableFunction[];
   marqueeTitleInterval: ReturnType<typeof setInterval> | null;
+	canvas: { [key: string]: HTMLCanvasElement };
 }
 
 declare global {
@@ -24,6 +25,7 @@ if (typeof window !== "undefined") {
     focusCallbacks: [],
     blurCallbacks: [],
     marqueeTitleInterval: null,
+		canvas: {},
   };
 
   window.addEventListener("focus", () => {

--- a/src/marquee-title.ts
+++ b/src/marquee-title.ts
@@ -14,7 +14,10 @@ export interface MarqueeTitleProps {
  * @param {number} [param0.interval] Marquee interval, how long to wait between scrolling letters (in milliseconds)
  * @returns {Interval}
  */
-export const marqueeTitle = ({ title, interval = 300 }: MarqueeTitleProps): ReturnType<typeof setInterval> => {
+export const marqueeTitle = ({
+  title,
+  interval = 300,
+}: MarqueeTitleProps): ReturnType<typeof setInterval> => {
   resetTitle();
   saveOriginalTitle();
   const fixedTitle = `${title.trim()} `;

--- a/src/swap-favicon.ts
+++ b/src/swap-favicon.ts
@@ -4,10 +4,10 @@ import { resetFavicon } from "./reset-favicon";
 
 export interface SwapFaviconProps {
   favicon: string;
-	when?: "now" | "onfocus" | "onblur";
+  when?: "now" | "onfocus" | "onblur";
   reset?: "none" | "after" | "onfocus" | "onblur";
   resetAfterMs?: number;
-	emojiCompatibilityMode?: boolean;
+  emojiCompatibilityMode?: boolean;
 }
 
 /**
@@ -26,7 +26,7 @@ export const swapFavicon = ({
   when = "now",
   reset = "none",
   resetAfterMs = 3000,
-	emojiCompatibilityMode = true,
+  emojiCompatibilityMode = true,
 }: SwapFaviconProps) => {
   const links = document.querySelectorAll("link[rel='icon']");
 


### PR DESCRIPTION
## Bug
- We were unnecessarily creating a canvas element each time if there were multiple icon sizes
- `addBadge()` behaves wonky if a site has multiple sized-favicons (for example `<link rel="icon" style="16x16px ...` and `<link rel="icon" style="32x32px ...`), seems the browser would shift between rendering each one.
- The font-size wasn't scaled for favicons that aren't 32px (so if you used `type: "count"` you ended up with huge numbers). This combined with behavior in previous point meant if you changed the favicon badge multiple times, sometimes you'd get huge numbers, sometimes normally sized.

## Fixes
- Store references to canvases for different sizes
- Clear canvas before drawing in each function
- Scale the font size depending on canvas size (normalized to 32px)
- Added `.editorconfig`
- Prettified all files